### PR TITLE
Updates for PuppetDB 3.x Metrics API

### DIFF
--- a/plugins/check_puppetdb_dups
+++ b/plugins/check_puppetdb_dups
@@ -54,11 +54,11 @@ $np->add_arg(
 $np->getopts;
 
 my %mbeans = (
-    'catalogs'  => 'com.puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct',
-    'resources' => 'com.puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes',
+    'catalogs'  => 'puppetlabs.puppetdb.scf.storage:type=default,name=duplicate-pct',
+    'resources' => 'puppetlabs.puppetdb.query.population:type=default,name=pct-resource-dupes',
 );
 
-my $base_url = sprintf('http%s://%s:%d/v2/metrics/mbean/', 
+my $base_url = sprintf('http%s://%s:%d/metrics/v1/mbeans/',
     defined($np->opts->ssl) ? 's' : '',
     $np->opts->host,
     $np->opts->port

--- a/plugins/check_puppetdb_memory
+++ b/plugins/check_puppetdb_memory
@@ -67,7 +67,7 @@ $np->add_arg(
 
 $np->getopts;
 
-my $base_url = sprintf('http%s://%s:%d/v2/metrics/mbean/', 
+my $base_url = sprintf('http%s://%s:%d/metrics/v1/mbeans/',
     defined($np->opts->ssl) ? 's' : '',
     $np->opts->host,
     $np->opts->port
@@ -87,6 +87,11 @@ if (!$response->is_success) {
 
 my $data = decode_json($response->decoded_content);
 
+$np->set_thresholds(
+    warning  => int($np->opts->warning  * .01 * $data->{'HeapMemoryUsage'}->{'max'}),
+    critical => int($np->opts->critical * .01 * $data->{'HeapMemoryUsage'}->{'max'}),
+);
+
 $np->add_perfdata(
     label => 'maximum',
     value => $data->{'HeapMemoryUsage'}->{'max'}, 
@@ -97,12 +102,11 @@ $np->add_perfdata(
     label => 'used',
     value => $data->{'HeapMemoryUsage'}->{'used'}, 
     uom   => undef,
+    threshold => $np->threshold(),
 );
 
 my $code = $np->check_threshold(
     check    => $data->{'HeapMemoryUsage'}->{'used'},
-    warning  => $np->opts->warning  * .01 * $data->{'HeapMemoryUsage'}->{'max'},
-    critical => $np->opts->critical * .01 * $data->{'HeapMemoryUsage'}->{'max'},
 );
 
 $np->nagios_exit(

--- a/plugins/check_puppetdb_populations
+++ b/plugins/check_puppetdb_populations
@@ -54,11 +54,11 @@ $np->add_arg(
 $np->getopts;
 
 my %mbeans = (
-    'resources' => 'com.puppetlabs.puppetdb.query.population:type=default,name=num-resources',
-    'nodes'     => 'com.puppetlabs.puppetdb.query.population:type=default,name=num-nodes',
+    'resources' => 'puppetlabs.puppetdb.query.population:type=default,name=num-resources',
+    'nodes'     => 'puppetlabs.puppetdb.query.population:type=default,name=num-nodes',
 );
 
-my $base_url = sprintf('http%s://%s:%d/v2/metrics/mbean/', 
+my $base_url = sprintf('http%s://%s:%d/metrics/v1/mbeans/',
     defined($np->opts->ssl) ? 's' : '',
     $np->opts->host,
     $np->opts->port

--- a/plugins/check_puppetdb_processed
+++ b/plugins/check_puppetdb_processed
@@ -60,7 +60,7 @@ $np->add_arg(
 
 $np->getopts;
 
-my $base_url = sprintf('http%s://%s:%d/v2/metrics/mbean/', 
+my $base_url = sprintf('http%s://%s:%d/metrics/v1/mbeans/',
     defined($np->opts->ssl) ? 's' : '',
     $np->opts->host,
     $np->opts->port
@@ -70,7 +70,7 @@ my $ua = new LWP::UserAgent;
 $ua->default_header('Accept' => 'application/json');
 
 
-my $url = $base_url . 'com.puppetlabs.puppetdb.command:type=global,name=processed';
+my $url = $base_url . 'puppetlabs.puppetdb.command:type=global,name=processed';
 my $response = $ua->get($url);
 
 if (!$response->is_success) {

--- a/plugins/check_puppetdb_queue
+++ b/plugins/check_puppetdb_queue
@@ -68,7 +68,7 @@ $np->add_arg(
 
 $np->getopts;
 
-my $base_url = sprintf('http%s://%s:%d/v2/metrics/mbean/', 
+my $base_url = sprintf('http%s://%s:%d/metrics/v1/mbeans/',
     defined($np->opts->ssl) ? 's' : '',
     $np->opts->host,
     $np->opts->port
@@ -78,7 +78,7 @@ my $ua = new LWP::UserAgent;
 $ua->default_header('Accept' => 'application/json');
 
 
-my $url = $base_url . 'org.apache.activemq:BrokerName=localhost,Type=Queue,Destination=com.puppetlabs.puppetdb.commands';
+my $url = $base_url . 'org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands';
 my $response = $ua->get($url);
 
 if (!$response->is_success) {


### PR DESCRIPTION
These changes make the plugins work with the PuppetDB 3.x Metrics API.

See this documentation for further details:
https://docs.puppetlabs.com/puppetdb/3.2/api/metrics/v1/mbeans.html
